### PR TITLE
Fixed sort links button crash

### DIFF
--- a/Sticky Links/View/Base.lproj/Main.storyboard
+++ b/Sticky Links/View/Base.lproj/Main.storyboard
@@ -70,7 +70,7 @@
                             </barButtonItem>
                             <barButtonItem title="Item" image="arrow.up.arrow.down" catalog="system" id="9AO-Y3-2OH">
                                 <connections>
-                                    <action selector="sortButton:" destination="X4Q-zs-uTj" id="kHM-RK-5S0"/>
+                                    <action selector="sortLinksButton:" destination="X4Q-zs-uTj" id="xfb-gv-b6x"/>
                                 </connections>
                             </barButtonItem>
                         </rightBarButtonItems>


### PR DESCRIPTION
Hey guys,

I've been using the app and when I tried to sort my links I received a crash. Looks like the sort button link to Interface Board was broken. So I fixed it :)

P.S. I'd appreciate if you put the hacktoberfest-accepted label to my PR to count it towards the Hacktoberfest goal.

Cheers!