### PR TITLE
Added categories

### DIFF
--- a/Sticky Links/Controllers/LinksViewController.swift
+++ b/Sticky Links/Controllers/LinksViewController.swift
@@ -16,6 +16,7 @@ class LinksViewController: UITableViewController {
     let request : NSFetchRequest<Items> = Items.fetchRequest()
     var selectedProperty:Category?{
         didSet{
+			request.predicate = NSPredicate(format: "parentCategory.name == %@", selectedProperty?.name ?? "")
             loadLink()
         }
     }


### PR DESCRIPTION
Links were not fetched by specific category when user wanted to browse some specific category. The result was any category displayed all the items.
Fixed this by adding an NSPredicate to the fetch request.

P.S. I'd appreciate if you put the hacktoberfest-accepted label to my PR to count it towards the Hacktoberfest goal.